### PR TITLE
fix: ensure commands immediately delegate to agents

### DIFF
--- a/plugins/swift-engineering/commands/build.md
+++ b/plugins/swift-engineering/commands/build.md
@@ -12,6 +12,8 @@ description: Build the project and check for errors/warnings
 > - **@tca-engineer** — Fixes TCA-specific errors if needed
 > - **@swiftui-specialist** — Fixes SwiftUI view errors if needed
 > - **@swift-test-creator** — Fixes test errors if needed
+>
+> <!-- MAINTENANCE: Keep this agent list in sync with available agents in plugin.yaml -->
 
 Build the project and resolve any compiler errors or warnings.
 

--- a/plugins/swift-engineering/commands/modernize.md
+++ b/plugins/swift-engineering/commands/modernize.md
@@ -9,6 +9,8 @@ description: Migrate legacy Swift patterns to modern best practices — async/aw
 > This command delegates to specialized agents:
 > - **@swift-modernizer** — Analyzes legacy code and migrates to modern Swift patterns
 > - **@swift-builder** — Verifies modernized code compiles and tests pass
+>
+> <!-- MAINTENANCE: Keep this agent list in sync with available agents in plugin.yaml -->
 
 Migrate legacy Swift code to modern best practices.
 

--- a/plugins/swift-engineering/commands/plan.md
+++ b/plugins/swift-engineering/commands/plan.md
@@ -10,6 +10,8 @@ description: Plan a Swift feature without implementing. Uses swift-architect age
 > - **@swift-ui-design** — Analyzes UI mockups/descriptions to inform architecture
 > - **@swift-architect** — Designs feature architecture and persistence strategy
 > - **@tca-architect** — Designs detailed TCA state/action/dependency structure (if TCA chosen)
+>
+> <!-- MAINTENANCE: Keep this agent list in sync with available agents in plugin.yaml -->
 
 Create an architecture plan for a Swift feature without implementing it.
 
@@ -66,19 +68,6 @@ Then ask about UI:
 > - Paste an image
 > - Describe the UI visually
 > - Say 'skip' to proceed without UI design analysis"
-
-Once you have a description:
-
-1. **Analyze the description** and suggest:
-   - Feature name (e.g., `UserProfile`)
-   - Likely files to create
-   - Architecture recommendation (TCA vs vanilla Swift) with rationale
-   - Persistence needs (SQLite, UserDefaults, CloudKit, or none)
-   - New dependencies needed
-
-2. **Present suggestions and ask for feedback**
-
-3. **Ask clarifying questions** if needed
 
 ### 2. Invoke Planning Agent
 

--- a/plugins/swift-engineering/commands/review.md
+++ b/plugins/swift-engineering/commands/review.md
@@ -11,6 +11,8 @@ description: Review Swift code for quality, security, performance, and HIG compl
 > - **@tca-engineer** — Fixes TCA-specific issues if needed
 > - **@swiftui-specialist** — Fixes SwiftUI view issues if needed
 > - **@swift-engineer** — Fixes general Swift issues if needed
+>
+> <!-- MAINTENANCE: Keep this agent list in sync with available agents in plugin.yaml -->
 
 Review Swift/iOS code for quality, security, performance, and HIG compliance.
 

--- a/plugins/swift-engineering/commands/test.md
+++ b/plugins/swift-engineering/commands/test.md
@@ -12,6 +12,8 @@ description: Run tests for the current project or feature
 > - **@tca-engineer** — Fixes TCA test issues if needed
 > - **@swiftui-specialist** — Fixes SwiftUI test issues if needed
 > - **@swift-engineer** — Fixes general Swift test issues if needed
+>
+> <!-- MAINTENANCE: Keep this agent list in sync with available agents in plugin.yaml -->
 
 Create and/or run tests for Swift features.
 


### PR DESCRIPTION
Commands were not emphasizing immediate agent invocation strongly enough, leading to Claude using EnterPlanMode or direct tool usage instead.

Updated all commands to match the /feature pattern with:
- Explicit "IMMEDIATELY Invoke Agent" sections
- Clear Task() call examples
- Strong warnings against EnterPlanMode and direct tool usage

This ensures proper delegation to specialized agents for all workflows.